### PR TITLE
Update credential env vars in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Guardener
+
+Guardener is an R package that wraps the Hedera Guardian API with helper functions for authentication, policy discovery, schema inspection, and data preparation. It is intended to make it easier to explore Guardian policies from R and to build payloads that conform to policy schemas.
+
+## Installation
+
+You can install the package from a local checkout using [`devtools`](https://devtools.r-lib.org/):
+
+```r
+# install.packages("devtools")
+devtools::install_local(".")
+```
+
+## Authentication
+
+Most functions expect a Guardian refresh token, which you can obtain with `Glogin()`. By default the function reads credentials from environment variables, so you can keep secrets out of scripts:
+
+```r
+RT <- Glogin(un = Sys.getenv("GUARDENER_USERNAME"),
+             pw = Sys.getenv("GUARDENER_PASSWORD"),
+             baseurl = "http://localhost:3000/")
+refresh_token <- RT$refreshToken
+```
+
+`Glogin()` returns the username, DID, role, and tokens, and will raise an error if authentication fails. The optional `baseurl` lets you point to a remote Guardian instance instead of the local default. Use `GgetAccessToken()` whenever you need a short-lived access token for subsequent API calls.
+
+## Core workflows
+
+### List available policies
+
+Use `GgetPolicies()` with your refresh token to list policies accessible to the current role. Set `returndf = TRUE` to receive a tibble instead of the raw API response. Paging parameters allow you to control the number of results returned.
+
+```r
+df_policies <- GgetPolicies(refresh_token,
+                            baseurl = "http://localhost:3000/",
+                            returndf = TRUE)
+```
+
+### Inspect a policy and its blocks
+
+`GgetPolicyConfig()` (used internally by `GgetPolicyBlocks()`) unwraps the nested policy configuration. For a quick view of actionable blocks and their schemas, call `GgetPolicyBlocks()` and filter the results by `blockType`.
+
+```r
+blocks <- GgetPolicyBlocks(refreshToken = refresh_token,
+                           policyId = df_policies$id,
+                           baseurl = "http://localhost:3000/")
+request_blocks <- dplyr::filter(blocks, blockType == "requestVcDocumentBlock")
+```
+
+### Retrieve schemas
+
+Use `GgetSchemas()` to fetch schemas either for a policy topic or across the registry. When you only need a specific schema, provide `schemaId` to bypass the broader query.
+
+```r
+df_schemas <- GgetSchemas(refreshToken = refresh_token,
+                          baseurl = "http://localhost:3000/",
+                          returndf = TRUE)
+```
+
+### Build schema-driven templates
+
+`GmakeSchemaTemplate()` transforms schema metadata into nested tibbles that mirror the required document structure. You can filter the tibble of schemas produced by `GgetSchemas()` to a target schema name and then call `GmakeSchemaTemplate()` to derive a template for data entry or validation.
+
+```r
+mr_template <- df_schemas %>%
+  dplyr::filter(name == "Monitoring Report (MR)") %>%
+  GmakeSchemaTemplate()
+```
+
+## Example session
+
+The included vignette walks through a full session: loading credentials from environment variables, logging in, listing policies, inspecting blocks, and preparing schema templates. See `vignettes/Overview.Rmd` for executable examples you can adapt to your own Guardian deployment.

--- a/vignettes/Overview.Rmd
+++ b/vignettes/Overview.Rmd
@@ -21,7 +21,7 @@ library(tidyverse)
 
 # Get access token
 
-You need to have a username and password. For the defaults, Use usethis::edit_r_environ() to edit the R environment. These value are be retrieved with Sys.getenv("shinyGuardianUN") and Sys.getenv("shinyGuardianPW")
+You need to have a username and password. For the defaults, Use usethis::edit_r_environ() to edit the R environment. These values can be retrieved with Sys.getenv("GUARDENER_USERNAME") and Sys.getenv("GUARDENER_PASSWORD")
 
 ```{r}
 #ATL <- Glogin(un = Sys.getenv("guardianUN2"), pw = Sys.getenv("guardianPW2"))
@@ -32,8 +32,8 @@ You need to have a username and password. For the defaults, Use usethis::edit_r_
 #RT <- ATL$refreshToken # only the accestoken
 dropbase <- gsub(":3838/HGICP-ShinyUI/", ":3000/", Sys.getenv("shinyGuardianURL"))
 
-RT <- Glogin(un = Sys.getenv("shinyGuardianUN"), 
-              pw = Sys.getenv("shinyGuardianPW"), 
+RT <- Glogin(un = Sys.getenv("GUARDENER_USERNAME"),
+              pw = Sys.getenv("GUARDENER_PASSWORD"),
               baseurl = dropbase)
 RT <- RT$refreshToken
 


### PR DESCRIPTION
## Summary
- replace credential environment variable placeholders in the README with clearer examples
- align the vignette login instructions with the updated credential variable names

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927ee795f0883239b874afc5e0afeec)